### PR TITLE
only show relevant commands

### DIFF
--- a/wall.py
+++ b/wall.py
@@ -73,7 +73,12 @@ while True:
         print("\nNo more posts to show.")
 
     # present options to the user
-    print("\n[P]ost a message [B]ack [F]orward [D]elete E[x]it")
+    print("\n[P]ost a message ", end="")
+    if start_index > 0:
+        print("[B]ack ", end="")
+    if num_messages > num_entries and start_index + num_entries < num_messages:
+        print("[F]orward ", end="")
+    print("[D]elete E[x]it")
     choice = input().lower().strip()
 
     if choice == "p":

--- a/wall.py
+++ b/wall.py
@@ -81,6 +81,11 @@ while True:
     print("[D]elete E[x]it")
     choice = input().lower().strip()
 
+    while choice not in ("p", "b", "f", "d", "x"):
+        print("Invalid command")
+        print("Commands are the letters in square brackets above")
+        choice = input().lower().strip()
+
     if choice == "p":
         # ask the user for a message
         message = input("Enter your post (limit {0} characters): ".format(max_message_length)).strip()[:max_message_length]


### PR DESCRIPTION
When Nodewall is first set up, there are not enough messages to make the forward and back commands work. This change turns them off until there are enough messages to make pagination happen.

When there are enough messages to paginate, it will hide the forward or back command if it is at the end or start of the list of messages so it only shows commands that can actually be used.